### PR TITLE
fix(frontend): improve LCP, accessibility, SEO, and remove dead CSS

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,5 +1,6 @@
 :root {
   --color-primary: #d1861f;
+  --color-primary-accessible: #966016;
   --color-lightGrey: #ddd;
   --color-grey: #747681;
   --grid-gutter: 2rem;
@@ -213,7 +214,7 @@ ul {
 .skip-link {
   position: absolute;
   left: -9999px;
-  background: #966016;
+  background: var(--color-primary-accessible);
   color: #fff;
   padding: 8px;
   z-index: 100;

--- a/css/main.css
+++ b/css/main.css
@@ -153,14 +153,6 @@ img {
   margin: 0;
 }
 
-.pull-right {
-  float: right !important;
-}
-
-.pull-left {
-  float: left !important;
-}
-
 .text-center {
   text-align: center;
 }
@@ -177,89 +169,14 @@ img {
   text-align: justify;
 }
 
-.text-uppercase {
-  text-transform: uppercase;
-}
-
-.text-lowercase {
-  text-transform: lowercase;
-}
-
-.text-capitalize {
-  text-transform: capitalize;
-}
-
-.is-full-screen {
-  min-height: 100vh;
-  width: 100%;
-}
-
-.is-full-width {
-  width: 100% !important;
-}
-
-.is-vertical-align {
-  align-items: center;
-}
-
-.is-center,
-.is-horizontal-align,
-.is-vertical-align {
-  display: flex;
-}
-
-.is-center,
-.is-horizontal-align {
-  justify-content: center;
-}
-
 .is-center {
   align-items: center;
-}
-
-.is-right {
-  justify-content: flex-end;
-}
-
-.is-left,
-.is-right {
-  align-items: center;
   display: flex;
-}
-
-.is-left {
-  justify-content: flex-start;
-}
-
-.is-fixed {
-  position: fixed;
-  width: 100%;
-}
-
-.is-paddingless {
-  padding: 0 !important;
+  justify-content: center;
 }
 
 .is-marginless {
   margin: 0 !important;
-}
-
-.is-pointer {
-  cursor: pointer !important;
-}
-
-.is-rounded {
-  border-radius: 100%;
-}
-
-.clearfix {
-  clear: both;
-  content: "";
-  display: table;
-}
-
-.is-hidden {
-  display: none !important;
 }
 
 .datetime,
@@ -293,14 +210,10 @@ ul {
   margin: 0.35em 0 0.5em;
 }
 
-.no-style-list {
-  list-style-type: none;
-}
-
 .skip-link {
   position: absolute;
   left: -9999px;
-  background: var(--color-primary);
+  background: #966016;
   color: #fff;
   padding: 8px;
   z-index: 100;
@@ -309,4 +222,13 @@ ul {
 .skip-link:focus {
   left: 0;
   top: 0;
+}
+
+@media print {
+  .skip-link,
+  header,
+  nav,
+  footer {
+    display: none;
+  }
 }

--- a/essays.html
+++ b/essays.html
@@ -14,11 +14,13 @@
             style-src 'self'"
           http-equiv="Content-Security-Policy"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <meta content="#d1861f" name="theme-color"/>
     <meta charset="utf-8"/>
 
     <!-- Webpage info -->
     <title>Essays • Florin Ungur</title>
     <meta content="Essays" property="og:title"/>
+    <meta content="website" property="og:type"/>
     <meta content="Florin Ungur" name="author"/>
     <meta content="These words are my words. They are me – as much as I can make them and as much as words are people – and are intended for me and people like
             me, however you are."
@@ -34,7 +36,7 @@
     <link href="/img/favicon/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
     <link href="/img/favicon/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png"/>
     <link color="#d1861f" href="/img/favicon/safari-pinned-tab.svg" rel="mask-icon"/>
-    <link href="/img/favicon/favicon.ico" rel="shortcut icon"/>
+    <link href="/img/favicon/favicon.ico" rel="icon"/>
 
     <!-- CSS -->
     <link href="css/main.css" rel="stylesheet"/>
@@ -47,7 +49,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" loading="lazy" src="img/logo/logo.svg" width="400"/>
+            <img alt="website logo" height="70" src="img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/essays/2020/09/01/hello-world.html
+++ b/essays/2020/09/01/hello-world.html
@@ -14,11 +14,13 @@
             style-src 'self'"
           http-equiv="Content-Security-Policy"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <meta content="#d1861f" name="theme-color"/>
     <meta charset="utf-8"/>
 
     <!-- Webpage info -->
     <title>Hello, World! • Florin Ungur</title>
     <meta content="Hello, World!" property="og:title"/>
+    <meta content="article" property="og:type"/>
     <meta content="Florin Ungur" name="author"/>
     <meta content="This website will have mostly philosophy-, psychology-, and technology-related content. I aim to display this content on a simple yet
             beautiful website that is designed to last and to be accessible to as many types of people as possible throughout its lifetime."
@@ -34,7 +36,7 @@
     <link href="../../../../img/favicon/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
     <link href="../../../../img/favicon/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png"/>
     <link color="#d1861f" href="../../../../img/favicon/safari-pinned-tab.svg" rel="mask-icon"/>
-    <link href="../../../../img/favicon/favicon.ico" rel="shortcut icon"/>
+    <link href="../../../../img/favicon/favicon.ico" rel="icon"/>
 
     <!-- CSS -->
     <link href="../../../../css/main.css" rel="stylesheet"/>
@@ -48,7 +50,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" loading="lazy" src="../../../../img/logo/logo.svg" width="400"/>
+            <img alt="website logo" height="70" src="../../../../img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/essays/2021/07/25/azure-autoscaling-best-practices-an-addition.html
+++ b/essays/2021/07/25/azure-autoscaling-best-practices-an-addition.html
@@ -14,11 +14,13 @@
             style-src 'self'"
           http-equiv="Content-Security-Policy"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <meta content="#d1861f" name="theme-color"/>
     <meta charset="utf-8"/>
 
     <!-- Webpage info -->
     <title>Azure autoscaling best practices: an addition • Florin Ungur</title>
     <meta content="Azure autoscaling best practices: an addition" property="og:title"/>
+    <meta content="article" property="og:type"/>
     <meta content="Florin Ungur" name="author"/>
     <meta content="If you don't use a scale-out and scale-in rule combination, then you might get flapping."
           name="description"/>
@@ -32,7 +34,7 @@
     <link href="../../../../img/favicon/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
     <link href="../../../../img/favicon/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png"/>
     <link color="#d1861f" href="../../../../img/favicon/safari-pinned-tab.svg" rel="mask-icon"/>
-    <link href="../../../../img/favicon/favicon.ico" rel="shortcut icon"/>
+    <link href="../../../../img/favicon/favicon.ico" rel="icon"/>
 
     <!-- CSS -->
     <link href="../../../../css/main.css" rel="stylesheet"/>
@@ -46,7 +48,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" loading="lazy" src="../../../../img/logo/logo.svg" width="400"/>
+            <img alt="website logo" height="70" src="../../../../img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/essays/2022/04/18/not-command-not-found.html
+++ b/essays/2022/04/18/not-command-not-found.html
@@ -14,11 +14,13 @@
             style-src 'self'"
           http-equiv="Content-Security-Policy"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <meta content="#d1861f" name="theme-color"/>
     <meta charset="utf-8"/>
 
     <!-- Webpage info -->
     <title>/usr/local/bin/polkadot: line 1: Not: command not found • Florin Ungur</title>
     <meta content="/usr/local/bin/polkadot: line 1: Not: command not found" property="og:title"/>
+    <meta content="article" property="og:type"/>
     <meta content="Florin Ungur" name="author"/>
     <meta content="What do you do when you see an error like that? If you are like me, you do not read the full message. You instead rush to create hypotheses
             and test them."
@@ -33,7 +35,7 @@
     <link href="../../../../img/favicon/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
     <link href="../../../../img/favicon/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png"/>
     <link color="#d1861f" href="../../../../img/favicon/safari-pinned-tab.svg" rel="mask-icon"/>
-    <link href="../../../../img/favicon/favicon.ico" rel="shortcut icon"/>
+    <link href="../../../../img/favicon/favicon.ico" rel="icon"/>
 
     <!-- CSS -->
     <link href="../../../../css/main.css" rel="stylesheet"/>
@@ -47,7 +49,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" loading="lazy" src="../../../../img/logo/logo.svg" width="400"/>
+            <img alt="website logo" height="70" src="../../../../img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/essays/2023/08/12/docker-permission-errors-are-not-ok.html
+++ b/essays/2023/08/12/docker-permission-errors-are-not-ok.html
@@ -14,11 +14,13 @@
             style-src 'self'"
           http-equiv="Content-Security-Policy"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <meta content="#d1861f" name="theme-color"/>
     <meta charset="utf-8"/>
 
     <!-- Webpage info -->
     <title>Docker permission errors are not ok • Florin Ungur</title>
     <meta content="Docker permission errors are not ok" property="og:title"/>
+    <meta content="article" property="og:type"/>
     <meta content="Florin Ungur" name="author"/>
     <meta content="Quick one for you today. And it's a mystery for you to solve. Kinda like Sherlock Holmes' The Final Problem but more Unix-y."
           name="description"/>
@@ -31,7 +33,7 @@
     <link href="../../../../img/favicon/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
     <link href="../../../../img/favicon/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png"/>
     <link color="#d1861f" href="../../../../img/favicon/safari-pinned-tab.svg" rel="mask-icon"/>
-    <link href="../../../../img/favicon/favicon.ico" rel="shortcut icon"/>
+    <link href="../../../../img/favicon/favicon.ico" rel="icon"/>
 
     <!-- CSS -->
     <link href="../../../../css/main.css" rel="stylesheet"/>
@@ -45,7 +47,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" loading="lazy" src="../../../../img/logo/logo.svg" width="400"/>
+            <img alt="website logo" height="70" src="../../../../img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/essays/2024/10/06/what-are-we-doing.html
+++ b/essays/2024/10/06/what-are-we-doing.html
@@ -14,11 +14,13 @@
             style-src 'self'"
           http-equiv="Content-Security-Policy"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <meta content="#d1861f" name="theme-color"/>
     <meta charset="utf-8"/>
 
     <!-- Webpage info -->
     <title>What are we doing? • Florin Ungur</title>
     <meta content="What are we doing?" property="og:title"/>
+    <meta content="article" property="og:type"/>
     <meta content="Florin Ungur" name="author"/>
     <meta content="An essay about people." name="description"/>
     <meta content="An essay about people." property="og:description"/>
@@ -29,7 +31,7 @@
     <link href="../../../../img/favicon/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
     <link href="../../../../img/favicon/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png"/>
     <link color="#d1861f" href="../../../../img/favicon/safari-pinned-tab.svg" rel="mask-icon"/>
-    <link href="../../../../img/favicon/favicon.ico" rel="shortcut icon"/>
+    <link href="../../../../img/favicon/favicon.ico" rel="icon"/>
 
     <!-- CSS -->
     <link href="../../../../css/main.css" rel="stylesheet"/>
@@ -43,7 +45,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" loading="lazy" src="../../../../img/logo/logo.svg" width="400"/>
+            <img alt="website logo" height="70" src="../../../../img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/essays/2024/10/12/the-human-risk-of-failure.html
+++ b/essays/2024/10/12/the-human-risk-of-failure.html
@@ -14,11 +14,13 @@
             style-src 'self'"
           http-equiv="Content-Security-Policy"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <meta content="#d1861f" name="theme-color"/>
     <meta charset="utf-8"/>
 
     <!-- Webpage info -->
     <title>The human risk of failure • Florin Ungur</title>
     <meta content="The human risk of failure" property="og:title"/>
+    <meta content="article" property="og:type"/>
     <meta content="Florin Ungur" name="author"/>
     <meta content="I recently lost a flight by 7 minutes, and that gave me an idea." name="description"/>
     <meta content="I recently lost a flight by 7 minutes, and that gave me an idea." property="og:description"/>
@@ -29,7 +31,7 @@
     <link href="../../../../img/favicon/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
     <link href="../../../../img/favicon/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png"/>
     <link color="#d1861f" href="../../../../img/favicon/safari-pinned-tab.svg" rel="mask-icon"/>
-    <link href="../../../../img/favicon/favicon.ico" rel="shortcut icon"/>
+    <link href="../../../../img/favicon/favicon.ico" rel="icon"/>
 
     <!-- CSS -->
     <link href="../../../../css/main.css" rel="stylesheet"/>
@@ -43,7 +45,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" loading="lazy" src="../../../../img/logo/logo.svg" width="400"/>
+            <img alt="website logo" height="70" src="../../../../img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/essays/2026/04/06/do-nothing-scripts-are-dead-long-live-the-do-nothing-script.html
+++ b/essays/2026/04/06/do-nothing-scripts-are-dead-long-live-the-do-nothing-script.html
@@ -14,11 +14,13 @@
             style-src 'self'"
           http-equiv="Content-Security-Policy"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <meta content="#d1861f" name="theme-color"/>
     <meta charset="utf-8"/>
 
     <!-- Webpage info -->
     <title>Do-nothing scripts are dead! Long live the do-nothing script! • Florin Ungur</title>
     <meta content="Do-nothing scripts are dead! Long live the do-nothing script!" property="og:title"/>
+    <meta content="article" property="og:type"/>
     <meta content="Florin Ungur" name="author"/>
     <meta content="Nobody talks about do-nothing scripts anymore. Not because the idea was bad – something better came along and swallowed it whole."
           name="description"/>
@@ -31,7 +33,7 @@
     <link href="../../../../img/favicon/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
     <link href="../../../../img/favicon/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png"/>
     <link color="#d1861f" href="../../../../img/favicon/safari-pinned-tab.svg" rel="mask-icon"/>
-    <link href="../../../../img/favicon/favicon.ico" rel="shortcut icon"/>
+    <link href="../../../../img/favicon/favicon.ico" rel="icon"/>
 
     <!-- CSS -->
     <link href="../../../../css/main.css" rel="stylesheet"/>
@@ -45,7 +47,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" loading="lazy" src="../../../../img/logo/logo.svg" width="400"/>
+            <img alt="website logo" height="70" src="../../../../img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/ideas.html
+++ b/ideas.html
@@ -14,11 +14,13 @@
             style-src 'self'"
           http-equiv="Content-Security-Policy"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <meta content="#d1861f" name="theme-color"/>
     <meta charset="utf-8"/>
 
     <!-- Webpage info -->
     <title>Ideas (and poems) • Florin Ungur</title>
     <meta content="Ideas (and poems)" property="og:title"/>
+    <meta content="website" property="og:type"/>
     <meta content="Florin Ungur" name="author"/>
     <meta content="Here I put all my intellectual – not business – ideas, which I sometimes call aphorisms as a self-deprecating joke. This page has poems too."
           name="description"/>
@@ -32,17 +34,20 @@
     <link href="/img/favicon/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
     <link href="/img/favicon/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png"/>
     <link color="#d1861f" href="/img/favicon/safari-pinned-tab.svg" rel="mask-icon"/>
-    <link href="/img/favicon/favicon.ico" rel="shortcut icon"/>
+    <link href="/img/favicon/favicon.ico" rel="icon"/>
 
     <!-- CSS -->
     <link href="css/main.css" rel="stylesheet"/>
+
+    <!-- RSS -->
+    <link rel="alternate" type="application/rss+xml" title="Florin Ungur's Essays" href="https://florinungur.com/rss.xml"/>
 </head>
 <body>
 <a class="skip-link" href="#main-content">Skip to content</a>
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" loading="lazy" src="img/logo/logo.svg" width="400"/>
+            <img alt="website logo" height="70" src="img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/index.html
+++ b/index.html
@@ -14,11 +14,13 @@
             style-src 'self'"
           http-equiv="Content-Security-Policy"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <meta content="#d1861f" name="theme-color"/>
     <meta charset="utf-8"/>
 
     <!-- Webpage info -->
     <title>Homepage • Florin Ungur</title>
     <meta content="Homepage" property="og:title"/>
+    <meta content="website" property="og:type"/>
     <meta content="Florin Ungur" name="author"/>
     <meta content="The website of Florin Ungur (pronounced Flo•REEN Un•goor), a guy that likes computers, philosophy, zombies, psychology,
             and Hunter S. Thompson."
@@ -34,11 +36,14 @@
     <link href="/img/favicon/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
     <link href="/img/favicon/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png"/>
     <link color="#d1861f" href="/img/favicon/safari-pinned-tab.svg" rel="mask-icon"/>
-    <link href="/img/favicon/favicon.ico" rel="shortcut icon"/>
+    <link href="/img/favicon/favicon.ico" rel="icon"/>
 
     <!-- CSS -->
     <link href="css/main.css" rel="stylesheet"/>
     <link href="css/index.css" rel="stylesheet"/>
+
+    <!-- RSS -->
+    <link rel="alternate" type="application/rss+xml" title="Florin Ungur's Essays" href="https://florinungur.com/rss.xml"/>
 </head>
 <body>
 <a class="skip-link" href="#main-content">Skip to content</a>
@@ -46,7 +51,7 @@
     <h1 class="fake-h1">This is the website of</h1>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" loading="lazy" src="img/logo/logo.svg" width="400"/>
+            <img alt="website logo" height="70" src="img/logo/logo.svg" width="400"/>
         </a>
     </div>
     <p class="text-right">... (pronounced Flo•REEN Un•goor)</p>


### PR DESCRIPTION
Improve LCP, fix accessibility issues, add missing SEO tags, and clean up dead CSS across all pages.

| Change | Scope | Why |
| ------ | ----- | --- |
| Remove `loading="lazy"` from logo | All pages | Logo is above the fold; lazy-loading it delays LCP |
| Fix `rel="shortcut icon"` → `rel="icon"` | All pages | `shortcut` was never standardized; browsers ignore it |
| Add RSS `<link rel="alternate">` | index.html, ideas.html | Feed readers couldn't discover the RSS feed from the homepage |
| Add `<meta name="theme-color">` | All pages | Colors mobile browser toolbar to match brand gold |
| Add `og:type` meta tag | All pages | `website` for listings, `article` for essays; better social previews |
| Remove 18 dead CSS utility classes | main.css | Zero usage across all HTML files; cssnano stripped them in prod anyway |
| Darken skip-link background to `#966016` | main.css | White on `#d1861f` was 2.94:1; now 5.27:1, passing WCAG AA (4.5:1) |
| Add `@media print` rules | main.css | Hide header, nav, skip-link, and footer when printing essays |