### PR TITLE
fix(content): repair image fallback, drop dead links, clean up ideas and resume

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,18 +49,18 @@ Run `make hooks` once after cloning to enable pre-commit image optimization (`.p
 
 All links in essays use `target="_blank"` – including internal links to other florinungur.com pages. External links also get `rel="noopener"`. The archive-links script skips florinungur.com URLs (self-links), so internal links won't get `[archived link]` annotations.
 
-## Essay "Updated on" convention
+## Essay "Last updated" convention
 
-When modifying an essay, add an update note in the datetime div:
+Each essay carries at most ONE update note in the datetime div – the most recent substantive update. A new update replaces the old note; the full changelog lives in git history. Trivial fixes (dead links, typos) don't bump the note.
 
 ```html
 <div class="datetime">
     <time datetime="YYYY-MM-DD">Mon DD, YYYY</time> |
-    <i>Updated on <time datetime="YYYY-MM-DD">Mon DD, YYYY</time>: short description of changes</i>
+    <i>Last updated <time datetime="YYYY-MM-DD">Mon DD, YYYY</time>: terse description</i>
 </div>
 ```
 
-Multiple updates are chained with ` | `. See `hello-world.html` for an example with two update notes.
+Never chain multiple update notes.
 
 ## Archive links
 

--- a/essays/2020/09/01/hello-world.html
+++ b/essays/2020/09/01/hello-world.html
@@ -62,8 +62,7 @@
     <div class="subtitle">Or: How I finally decided to create my website</div>
     <div class="datetime">
         <time datetime="2020-09-01">Sep 1, 2020</time> | <i>Updated on <time datetime="2022-07-10">Jul 10, 2022</time>: changed logo and some wording</i> |
-        <i>Updated on <time datetime="2026-03-16">Mar 16, 2026</time>: added archived links, fixed HTML, added accessibility improvements, and added editor's note to the Tooling section</i> |
-        <i>Updated on <time datetime="2026-07-11">Jul 11, 2026</time>: removed link to the retired webmarks page</i>
+        <i>Updated on <time datetime="2026-03-16">Mar 16, 2026</time>: added archived links, fixed HTML, added accessibility improvements, and added editor's note to the Tooling section</i>
     </div>
     <p>This website will have mostly philosophy-, psychology-, and technology-related content. I aim to display this content on a simple yet beautiful website
         that is designed to last and to be accessible to as many types of people as possible throughout its lifetime.</p>

--- a/essays/2020/09/01/hello-world.html
+++ b/essays/2020/09/01/hello-world.html
@@ -62,7 +62,8 @@
     <div class="subtitle">Or: How I finally decided to create my website</div>
     <div class="datetime">
         <time datetime="2020-09-01">Sep 1, 2020</time> | <i>Updated on <time datetime="2022-07-10">Jul 10, 2022</time>: changed logo and some wording</i> |
-        <i>Updated on <time datetime="2026-03-16">Mar 16, 2026</time>: added archived links, fixed HTML, added accessibility improvements, and added editor's note to the Tooling section</i>
+        <i>Updated on <time datetime="2026-03-16">Mar 16, 2026</time>: added archived links, fixed HTML, added accessibility improvements, and added editor's note to the Tooling section</i> |
+        <i>Updated on <time datetime="2026-07-11">Jul 11, 2026</time>: removed link to the retired webmarks page</i>
     </div>
     <p>This website will have mostly philosophy-, psychology-, and technology-related content. I aim to display this content on a simple yet beautiful website
         that is designed to last and to be accessible to as many types of people as possible throughout its lifetime.</p>
@@ -149,7 +150,6 @@
             [<a href="https://web.archive.org/web/20201219200305/https://rxi.github.io/" rel="noopener" target="_blank">archived link</a>]
         </li>
     </ul>
-    <p>I was also probably inspired by my <a href="../../../../webmarks" target="_blank">webmarks</a>.</p>
     <h2>Tooling</h2>
     <p>For the technically inclined, here are the tools I use for this website:</p>
     <ul>

--- a/essays/2020/09/01/hello-world.html
+++ b/essays/2020/09/01/hello-world.html
@@ -61,8 +61,8 @@
     <h1>Hello, World!</h1>
     <div class="subtitle">Or: How I finally decided to create my website</div>
     <div class="datetime">
-        <time datetime="2020-09-01">Sep 1, 2020</time> | <i>Updated on <time datetime="2022-07-10">Jul 10, 2022</time>: changed logo and some wording</i> |
-        <i>Updated on <time datetime="2026-03-16">Mar 16, 2026</time>: added archived links, fixed HTML, added accessibility improvements, and added editor's note to the Tooling section</i>
+        <time datetime="2020-09-01">Sep 1, 2020</time> |
+        <i>Last updated <time datetime="2026-03-16">Mar 16, 2026</time>: archived links, HTML and accessibility fixes, editor's note</i>
     </div>
     <p>This website will have mostly philosophy-, psychology-, and technology-related content. I aim to display this content on a simple yet beautiful website
         that is designed to last and to be accessible to as many types of people as possible throughout its lifetime.</p>

--- a/essays/2021/07/25/azure-autoscaling-best-practices-an-addition.html
+++ b/essays/2021/07/25/azure-autoscaling-best-practices-an-addition.html
@@ -59,14 +59,15 @@
     <h1>Azure autoscaling best practices: an addition</h1>
     <div class="datetime">
         <time datetime="2021-07-25">Jul 25, 2021</time> |
-        <i>Updated on <time datetime="2026-03-16">Mar 16, 2026</time>: added archived links and accessibility improvements</i>
+        <i>Updated on <time datetime="2026-03-16">Mar 16, 2026</time>: added archived links and accessibility improvements</i> |
+        <i>Updated on <time datetime="2026-07-11">Jul 11, 2026</time>: fixed image fallback and formula wording</i>
     </div>
     <p>If you don't use a scale-out and scale-in rule combination, then you might get flapping.</p>
     <figure>
         <picture>
             <source srcset="img1-abstract-painting.webp" type="image/webp"/>
             <source srcset="img1-abstract-painting.png" type="image/png"/>
-            <img alt="AI-generated abstract painting" height="742" loading="lazy" src="img1.png" width="742"/>
+            <img alt="AI-generated abstract painting" height="742" loading="lazy" src="img1-abstract-painting.png" width="742"/>
         </picture>
         <figcaption class="text-center">AI-generated abstract painting, courtesy of
             <cite>
@@ -138,7 +139,7 @@
         HTTP errors but not the flapping. Flapping should have no longer occurred, but, instead, the ASP was stuck with 2 instances.</p>
     <p>The autoscale engine determines when to scale-in based on this formula:</p>
     <pre>
-<!-- --><code>used scale-in metric types x current instance count / final number of instances when scaled down</code><!--
+<!-- --><code>used scale-in metric value x current instance count / final number of instances when scaled down</code><!--
  --></pre>
     <p>The reasoning behind this equation is simple: if you have a workload that is divided across N instances that is to be moved to, for example, N - 1
         instances, then the N - 1 instances should be able to handle the workload that was present on the N instances.</p>

--- a/essays/2021/07/25/azure-autoscaling-best-practices-an-addition.html
+++ b/essays/2021/07/25/azure-autoscaling-best-practices-an-addition.html
@@ -59,8 +59,7 @@
     <h1>Azure autoscaling best practices: an addition</h1>
     <div class="datetime">
         <time datetime="2021-07-25">Jul 25, 2021</time> |
-        <i>Updated on <time datetime="2026-03-16">Mar 16, 2026</time>: added archived links and accessibility improvements</i> |
-        <i>Updated on <time datetime="2026-07-11">Jul 11, 2026</time>: fixed image fallback and formula wording</i>
+        <i>Last updated <time datetime="2026-07-11">Jul 11, 2026</time>: fixed image fallback and formula wording</i>
     </div>
     <p>If you don't use a scale-out and scale-in rule combination, then you might get flapping.</p>
     <figure>

--- a/essays/2022/04/18/not-command-not-found.html
+++ b/essays/2022/04/18/not-command-not-found.html
@@ -61,7 +61,7 @@
     <div class="subtitle">Or: A lesson in paying attention</div>
     <div class="datetime">
         <time datetime="2022-04-18">Apr 18, 2022</time> |
-        <i>Updated on <time datetime="2026-03-16">Mar 16, 2026</time>: added archived links and accessibility improvements</i>
+        <i>Last updated <time datetime="2026-03-16">Mar 16, 2026</time>: archived links and accessibility fixes</i>
     </div>
     <p class="dropcap">What do you do when you see an error like that? If you are like me, you do not read the full message. You instead rush to create
         hypotheses and test them.</p>

--- a/essays/2023/08/12/docker-permission-errors-are-not-ok.html
+++ b/essays/2023/08/12/docker-permission-errors-are-not-ok.html
@@ -57,8 +57,8 @@
 <main id="main-content">
     <h1>Docker permission errors are not ok</h1>
     <div class="datetime">
-        <time datetime="2023-08-12">Aug 12, 2023</time> | <i>Updated on <time datetime="2023-08-13">Aug 13, 2023</time>: added second solution</i> |
-        <i>Updated on <time datetime="2026-03-16">Mar 16, 2026</time>: added accessibility improvements</i>
+        <time datetime="2023-08-12">Aug 12, 2023</time> |
+        <i>Last updated <time datetime="2026-03-16">Mar 16, 2026</time>: accessibility fixes</i>
     </div>
     <p class="dropcap">Quick one for you today. And it's a mystery for you to solve. Kinda like Sherlock Holmes' The Final Problem but more Unix-y.</p>
     <p><b>First clue: </b>You have a simple <code>Dockerfile</code>.</p>

--- a/essays/2024/10/06/what-are-we-doing.html
+++ b/essays/2024/10/06/what-are-we-doing.html
@@ -56,7 +56,7 @@
     <h1>What are we doing?</h1>
     <div class="datetime">
         <time datetime="2024-10-06">Oct 6, 2024</time> |
-        <i>Updated on <time datetime="2026-03-16">Mar 16, 2026</time>: added accessibility improvements</i>
+        <i>Last updated <time datetime="2026-03-16">Mar 16, 2026</time>: accessibility fixes</i>
     </div>
     <p class="dropcap">Did you know that DuPont, a chemical company, knowingly poisoned the water of West Virginia with a Teflon-processing aid called PFOA? Two types of cancer, 5 other illnesses. Facial deformities, birth defects.</p>
     <p>What were they doing?</p>

--- a/essays/2024/10/12/the-human-risk-of-failure.html
+++ b/essays/2024/10/12/the-human-risk-of-failure.html
@@ -56,7 +56,7 @@
     <h1>The human risk of failure</h1>
     <div class="datetime">
         <time datetime="2024-10-12">Oct 12, 2024</time> |
-        <i>Updated on <time datetime="2026-03-16">Mar 16, 2026</time>: added archived links and accessibility improvements</i>
+        <i>Last updated <time datetime="2026-03-16">Mar 16, 2026</time>: archived links and accessibility fixes</i>
     </div>
     <p class="dropcap">I recently lost a flight by 7 minutes because my bus to the airport accrued 1 hour of delays. After trying everything with the staff at the boarding gate, I walked back with my tail behind my legs, through the duty free shops, through security, to buy another plane ticket. I got to talking with the lady at the check-in desk where I learned that airlines overbook seats. If everyone from my upcoming flight was to show up, I'd be reimbursed £400. On top of that, the airline would book the next available flight for me and pay for my overnight hotel stay if needed. Pretty sweet, no? There's even <a href="https://eur-lex.europa.eu/eli/reg/2004/261/oj" rel="noopener" target="_blank">a law</a>
             [<a href="http://web.archive.org/web/20260311143539/https://eur-lex.europa.eu/eli/reg/2004/261/oj" rel="noopener" target="_blank">archived link</a>] which stipulates reimbursements up to £500! However, she said that usually they have around 10 to 12 no-shows, so I shouldn't get my hopes up.</p>

--- a/ideas.html
+++ b/ideas.html
@@ -18,13 +18,13 @@
     <meta charset="utf-8"/>
 
     <!-- Webpage info -->
-    <title>Ideas (and poems) • Florin Ungur</title>
-    <meta content="Ideas (and poems)" property="og:title"/>
+    <title>Ideas • Florin Ungur</title>
+    <meta content="Ideas" property="og:title"/>
     <meta content="website" property="og:type"/>
     <meta content="Florin Ungur" name="author"/>
-    <meta content="Here I put all my intellectual – not business – ideas, which I sometimes call aphorisms as a self-deprecating joke. This page has poems too."
+    <meta content="Here I put all my intellectual – not business – ideas, which I sometimes call aphorisms as a self-deprecating joke."
           name="description"/>
-    <meta content="Here I put all my intellectual – not business – ideas, which I sometimes call aphorisms as a self-deprecating joke. This page has poems too."
+    <meta content="Here I put all my intellectual – not business – ideas, which I sometimes call aphorisms as a self-deprecating joke."
           property="og:description"/>
     <link href="https://florinungur.com/ideas" rel="canonical"/>
     <meta content="https://florinungur.com/ideas" property="og:url"/>
@@ -55,9 +55,11 @@
     <a href="/">← Home</a>
 </nav>
 <main id="main-content">
-    <h1>Ideas (and poems)</h1>
-    <div class="datetime">Updated on <time datetime="2026-03-04">March 4, 2026</time>: got rid of bad ideas and trimmed some fat</div>
-    <p>Here I put all my intellectual – not business – ideas, which I sometimes call aphorisms as a self-deprecating joke. This page has poems too.</p>
+    <h1>Ideas</h1>
+    <div class="datetime">Updated on <time datetime="2026-07-11">July 11, 2026</time>: removed ideas that turned out not to be mine, fixed typos, and dropped the
+        poems framing (the poems left in March)
+    </div>
+    <p>Here I put all my intellectual – not business – ideas, which I sometimes call aphorisms as a self-deprecating joke.</p>
     <nav aria-label="Table of contents">
         <ol>
             <li><a href="#on-truth">On Truth</a></li>
@@ -72,7 +74,6 @@
     <p class="is-center">❦</p>
     <h2 id="on-truth">On Truth</h2>
     <ul>
-        <li>Generalizations are, in general, false.</li>
         <li>The mistake is thinking that contemporary culture is Truth.</li>
         <li>Content is the result of forcefully pushing the mind to go from a playful, creative state – where one enjoys oneself – past to a desolate space full
             of half-finished ideas or half-truths or mediocre creativity. All in the search for an exhaustive story. Content is art put in a corner
@@ -94,11 +95,11 @@
             I when nobody else is around? If so, which one? The playful one? The serious one? Who am I? The silence which is the result of me quieting my mind?
             The person I am during sleep? The one during the first hour after waking up? The one during the last hour before sleep? The one on my worst day? Or
             on my best day? Am I all of these people? How overwhelming if so. I think I am who I am from second to second; the me now. And since sometimes I
-            don't take time to asses just who exactly I am... well... sometimes then I don't know who I am.
+            don't take time to assess just who exactly I am... well... sometimes then I don't know who I am.
         </li>
         <li>Let me tell you something about my mind, if you don't mind. Maybe you'll want to keep reading because you'll identify with it too. Maybe you'll want
             to let me know of our similarity and form a connection from it, maybe start a club or something. Anyways. My mind is like a memory foam mattress.
-            Whatever author, artist, or woman do I decide to invite into it, I will memorize part of them and, maybe, I will play something back on the same
+            Whoever I decide to invite into it – an author, an artist, a lover – I will memorize part of them and, maybe, play something back on the same
             theme, like a hopeful saxophone. People, ideas, stuff can leave an imprint on my mind. But all these imprints go away, or will go away, someday. Or
             will they?
         </li>
@@ -122,7 +123,7 @@
             Enjoying the beauty of budding cherry blossoms. Making fun of the smeared shit on the pavement. Giving love to a stranger through a smile. Yes,
             there's cold. But you already got used to it. So let the next bad thing happen with bravery. Because it's about the walk.
         </li>
-        <li>Deny the denier, the one who wishes for silence and not peace! Life is noise, energy, hurt, pain, nosebleeds, and runy noses. Peace is what you get
+        <li>Deny the denier, the one who wishes for silence and not peace! Life is noise, energy, hurt, pain, nosebleeds, and runny noses. Peace is what you get
             after a full day of life. Don't listen to that voice who logically negates the siren songs of life. Go with it.
         </li>
     </ul>
@@ -136,7 +137,6 @@
         <li>The sunrise is song, the sunset is poetry.</li>
         <li>Any excess in something shows a lack in something else.</li>
         <li>Don't take minimalism to its extreme: just because there is no need doesn't mean you shouldn't.</li>
-        <li>Comfort the afflicted and afflict the comfortable!</li>
         <li><q>It was his idea!</q> should be a praise, not an accusation – ideas appear rarely.</li>
         <li>Suffering is like gravitation, it has a continuous pull on your life. If you let it, gravity might hurt you. Same with suffering.</li>
         <li><b>Gödel and Existence:</b> we cannot prove Existence because that would mean using an apparatus that is external to it; impossible because

--- a/ideas.html
+++ b/ideas.html
@@ -56,9 +56,7 @@
 </nav>
 <main id="main-content">
     <h1>Ideas</h1>
-    <div class="datetime">Updated on <time datetime="2026-07-11">July 11, 2026</time>: removed ideas that turned out not to be mine, fixed typos, and dropped the
-        poems framing (the poems left in March)
-    </div>
+    <div class="datetime">Last updated <time datetime="2026-07-11">July 11, 2026</time>: removed borrowed ideas, fixed typos, dropped the poems framing</div>
     <p>Here I put all my intellectual – not business – ideas, which I sometimes call aphorisms as a self-deprecating joke.</p>
     <nav aria-label="Table of contents">
         <ol>

--- a/resume.html
+++ b/resume.html
@@ -42,7 +42,7 @@
 <main class="font-firago hyphens-manual">
     <!-- page -->
     <div class="p-6 mx-auto page max-w-2xl print:max-w-a4 md:max-w-a4 md:h-a4 xsm:p-8 sm:p-9 md:p-16 bg-white">
-        <time datetime="2026-04-12">Apr 12, 2026</time>
+        <time datetime="2026-07-11">Jul 11, 2026</time>
         <header class="flex items-center mb-4 md:mb-4">
             <h1 class="text-2xl font-bold pb-px uppercase">Florin</h1>
             <h1 class="text-2xl font-normal pb-px uppercase">Ungur</h1>
@@ -68,7 +68,7 @@
                 <section class="mb-4 break-inside-avoid">
                     <header class="mb-2.1">
                         <h3 class="text-md font-semibold leading-relaxed">Apple</h3>
-                        <p class="leading-normal text-sm">Site Reliability Engineer, PCC | July 2024 – Present &#8226; &lt;2 years | London, UK</p>
+                        <p class="leading-normal text-sm">Site Reliability Engineer, PCC | Jul 2024 – Present &#8226; &lt;2 years | London, UK</p>
                     </header>
                     <p class="mb-2.1">Part of the team responsible for the reliability of Private Cloud Compute (PCC), the infrastructure powering Apple
                         Intelligence.</p>
@@ -77,7 +77,7 @@
                 <section class="mb-4 break-inside-avoid">
                     <header class="mb-2.1">
                         <h3 class="text-md font-semibold leading-relaxed">Blockchain.com</h3>
-                        <p class="leading-normal text-sm">Site Reliability Engineer | Mar 2022 – July 2024 &#8226; &gt;2 years | London, UK</p>
+                        <p class="leading-normal text-sm">Site Reliability Engineer | Mar 2022 – Jul 2024 &#8226; &gt;2 years | London, UK</p>
                     </header>
                     <p class="mb-2.1">Weathered multiple crypto winters and summers, contributing to the company's $6B valuation through dozens of initiatives.
                         Main projects:</p>
@@ -126,7 +126,7 @@
                         <p class="leading-normal text-sm">Infrastructure (Security) Engineer | Feb 2020 – Jun 2021 &#8226; &lt;2 years | Hengelo, NL</p>
                     </header>
                     <p class="mb-2.1">I am proud to say that I have played a part in transitioning TACTICOS, the operating system of battleships operated by
-                        tens of military forces around the world, from an Ada-based orchestrator to Kubernetes. Key contributions:</p>
+                        dozens of navies around the world, from an Ada-based orchestrator to Kubernetes. Key contributions:</p>
                     <ul class="mt-2.1 mb-2.1 leading-normal">
                         <li>› <b>Proved that Kubernetes is military-grade: </b> Created Java Cucumber tests for Kubernetes that proved the orchestrator's
                             robustness in Thales' environment:
@@ -159,13 +159,12 @@
                     <ul class="mt-2.1 mb-2.1 leading-normal">
                         <li>› Graduated <i>cum laude</i> with an average of 8.4/10; top of the 2020 class.</li>
                         <li>› Note-worthy modules: Architecting the Cloud, Cloud Engineering, Servers & Services, Networking.</li>
-                        <li>› Recommended for my work by Tonny Lievers.</li>
                     </ul>
                 </section>
                 <section class="mb-4 break-inside-avoid">
                     <header class="mb-2.1">
                         <h3 class="text-md font-semibold leading-relaxed">University of Twente</h3>
-                        <p class="leading-normal text-sm">Minor in Psychology | Feb 2019 – July 2019</p>
+                        <p class="leading-normal text-sm">Minor in Psychology | Feb 2019 – Jul 2019</p>
                     </header>
                     <ul class="mt-2.1 mb-2.1 leading-normal">
                         <li>› Graduated with an average of 8/10; top 5% of the class.</li>


### PR DESCRIPTION
Fix a broken image fallback in the Azure essay, remove stale content (dead webmarks link, poems framing, borrowed aphorisms, outdated resume wording), and collapse chained essay update notes into a single "Last updated" line per page.