### PR TITLE
fix(a11y): descriptive link names and screen-reader new-tab warnings

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -191,6 +191,12 @@ ul {
   line-height: 1.9em;
 }
 
+/* Screen-reader-only warning for the site-wide new-tab link convention.
+   Empty visual content + alternative text; unsupporting browsers drop the declaration. */
+a[target="_blank"]::after {
+  content: "" / " (opens in a new tab)";
+}
+
 .content-list {
   margin-bottom: calc(var(--grid-gutter) / 2);
 }

--- a/essays.html
+++ b/essays.html
@@ -49,7 +49,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" src="img/logo/logo.svg" width="400"/>
+            <img alt="Florin Ungur" height="70" src="img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>
@@ -60,7 +60,7 @@
     <h1>My essays</h1>
     <p>These words are my words. They are me – as much as I can make them and as much as words are people – and are intended for me and people like me, however
         you are.</p>
-    <p>You can get an RSS feed <a href="rss.xml" target="_blank">here</a>.</p>
+    <p>You can get the <a href="rss.xml" target="_blank">RSS feed</a>.</p>
     <div class="content-list">
         <a href="https://florinungur.com/essays/2026/04/06/do-nothing-scripts-are-dead-long-live-the-do-nothing-script">
             <div class="card">

--- a/essays/2020/09/01/hello-world.html
+++ b/essays/2020/09/01/hello-world.html
@@ -50,7 +50,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" src="../../../../img/logo/logo.svg" width="400"/>
+            <img alt="Florin Ungur" height="70" src="../../../../img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/essays/2021/07/25/azure-autoscaling-best-practices-an-addition.html
+++ b/essays/2021/07/25/azure-autoscaling-best-practices-an-addition.html
@@ -48,7 +48,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" src="../../../../img/logo/logo.svg" width="400"/>
+            <img alt="Florin Ungur" height="70" src="../../../../img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/essays/2022/04/18/not-command-not-found.html
+++ b/essays/2022/04/18/not-command-not-found.html
@@ -49,7 +49,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" src="../../../../img/logo/logo.svg" width="400"/>
+            <img alt="Florin Ungur" height="70" src="../../../../img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/essays/2023/08/12/docker-permission-errors-are-not-ok.html
+++ b/essays/2023/08/12/docker-permission-errors-are-not-ok.html
@@ -47,7 +47,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" src="../../../../img/logo/logo.svg" width="400"/>
+            <img alt="Florin Ungur" height="70" src="../../../../img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/essays/2024/10/06/what-are-we-doing.html
+++ b/essays/2024/10/06/what-are-we-doing.html
@@ -45,7 +45,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" src="../../../../img/logo/logo.svg" width="400"/>
+            <img alt="Florin Ungur" height="70" src="../../../../img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/essays/2024/10/12/the-human-risk-of-failure.html
+++ b/essays/2024/10/12/the-human-risk-of-failure.html
@@ -45,7 +45,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" src="../../../../img/logo/logo.svg" width="400"/>
+            <img alt="Florin Ungur" height="70" src="../../../../img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/essays/2026/04/06/do-nothing-scripts-are-dead-long-live-the-do-nothing-script.html
+++ b/essays/2026/04/06/do-nothing-scripts-are-dead-long-live-the-do-nothing-script.html
@@ -47,7 +47,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" src="../../../../img/logo/logo.svg" width="400"/>
+            <img alt="Florin Ungur" height="70" src="../../../../img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/ideas.html
+++ b/ideas.html
@@ -47,7 +47,7 @@
 <header>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" src="img/logo/logo.svg" width="400"/>
+            <img alt="Florin Ungur" height="70" src="img/logo/logo.svg" width="400"/>
         </a>
     </div>
 </header>

--- a/index.html
+++ b/index.html
@@ -51,12 +51,13 @@
     <h1 class="fake-h1">This is the website of</h1>
     <div class="logo is-center">
         <a href="/">
-            <img alt="website logo" height="70" src="img/logo/logo.svg" width="400"/>
+            <img alt="Florin Ungur" height="70" src="img/logo/logo.svg" width="400"/>
         </a>
     </div>
     <p class="text-right">... (pronounced Flo•REEN Un•goor)</p>
-    <p class="text-center"><a href="https://hotlinewebring.club/florin/previous">←</a> Part of the <a href="https://hotlinewebring.club/">Hotline Webring</a>
-        <a href="https://hotlinewebring.club/florin/next">→</a>
+    <p class="text-center"><a aria-label="Previous webring site" href="https://hotlinewebring.club/florin/previous">←</a> Part of the
+        <a href="https://hotlinewebring.club/">Hotline Webring</a>
+        <a aria-label="Next webring site" href="https://hotlinewebring.club/florin/next">→</a>
     </p>
     <h2>Who?</h2>
     <p>A guy that likes computers, philosophy, zombies, psychology, and Hunter S. Thompson.</p>

--- a/resume.html
+++ b/resume.html
@@ -44,8 +44,7 @@
     <div class="p-6 mx-auto page max-w-2xl print:max-w-a4 md:max-w-a4 md:h-a4 xsm:p-8 sm:p-9 md:p-16 bg-white">
         <time datetime="2026-07-11">Jul 11, 2026</time>
         <header class="flex items-center mb-4 md:mb-4">
-            <h1 class="text-2xl font-bold pb-px uppercase">Florin</h1>
-            <h1 class="text-2xl font-normal pb-px uppercase">Ungur</h1>
+            <h1 class="flex items-center text-2xl pb-px uppercase"><span class="font-bold">Florin</span><span class="font-normal">Ungur</span></h1>
         </header>
         <p class="mb-4">
             <a href="https://github.com/florinungur" rel="noopener" target="_blank">github.com/florinungur</a> &nbsp;|&nbsp;

--- a/resume.html
+++ b/resume.html
@@ -44,7 +44,7 @@
     <div class="p-6 mx-auto page max-w-2xl print:max-w-a4 md:max-w-a4 md:h-a4 xsm:p-8 sm:p-9 md:p-16 bg-white">
         <time datetime="2026-07-11">Jul 11, 2026</time>
         <header class="flex items-center mb-4 md:mb-4">
-            <h1 class="flex items-center text-2xl pb-px uppercase"><span class="font-bold">Florin</span><span class="font-normal">Ungur</span></h1>
+            <h1 aria-label="Florin Ungur" class="flex items-center text-2xl pb-px uppercase"><span class="font-bold">Florin</span><span class="font-normal">Ungur</span></h1>
         </header>
         <p class="mb-4">
             <a href="https://github.com/florinungur" rel="noopener" target="_blank">github.com/florinungur</a> &nbsp;|&nbsp;


### PR DESCRIPTION
Fix the accessibility gaps from a manual audit: the webring arrow links get aria-labels, the logo alt text becomes the site name instead of "website logo", the essays-page RSS link text is now descriptive, and the resume header uses a single h1 with an aria-label so screen readers announce "Florin Ungur" instead of the visually-mashed "FlorinUngur".

Links with `target="_blank"` now announce "(opens in a new tab)" to screen readers via CSS `content` alternative text – no visual change, and browsers without support for the syntax drop the declaration cleanly.